### PR TITLE
ID-40: Fix "services" box rendering bugs

### DIFF
--- a/app/environment.js
+++ b/app/environment.js
@@ -84,6 +84,9 @@ if ('development' === app.get('env')) {
   }));
   app.use(connect.logger('dev'));
 
+  var edt = require('express-debug');
+  edt(app, {});
+
   app.use('/resource', lessMiddleware('/less', {
     dest: '/stylesheets',
     pathRoot: path.join(__dirname, '/../resource/')

--- a/app/model/index.js
+++ b/app/model/index.js
@@ -1,0 +1,13 @@
+var fs = require('fs');
+
+fs.readdirSync(__dirname).forEach(function(file) {
+  console.debug(file);
+
+  var regex = /^(.*).js$/.exec(file);
+  if (!regex[1]) return;
+
+  var name = regex[1];
+  if (name === 'index') return;
+
+  module.exports[name] = require('./' + name);
+});

--- a/app/openmrsid-common.js
+++ b/app/openmrsid-common.js
@@ -20,6 +20,7 @@ exports.mid           = require('./express-middleware');
 exports.renderHelpers = require('./render-helpers');
 exports.utils         = require('./utils');
 exports.validate      = require('./validate');
+exports.models        = require('./model');
 
 
 /*

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "supertest": "~0.8.2",
     "should": "~2.1.1",
     "mocha": "~1.16.2",
-    "chai": "~1.9.1"
+    "chai": "~1.9.1",
+    "express-debug": "~1.1.0"
   },
   "scripts": {
     "test": "mocha app/**/*.test.js"

--- a/resource/less/box.less
+++ b/resource/less/box.less
@@ -28,10 +28,12 @@
   content: '\279D \ ';
 }
 #main .box {
-  width: 287px;
-  height: 61px;
-  float: left;
   margin: 0 5px 5px 0;
   padding-top: 6px;
-  line-height: 16px;
+  line-height: 0.9em;
+  min-height: 70px;
+
+  h2 {
+    white-space: nowrap;
+  }
 }

--- a/resource/less/box.less
+++ b/resource/less/box.less
@@ -3,6 +3,10 @@
   margin-bottom: 8px;
   background: #F0ECE4;
   border: solid 1px #e3ded5;
+
+  h2 {
+    margin-top: 0;
+  }
 }
 .box img {
   display: block;

--- a/views/root.ejs
+++ b/views/root.ejs
@@ -14,25 +14,26 @@ Welcome, we're glad you joined us! If you haven't already, you should complete t
 
 <p class="clear"><h2>Services</h2>
 With your OpenMRS ID, you can log in to use the services below:</p>
-<div class="box no-ext-icon">
+
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/confluence.png" alt="OpenMRS Wiki"></div>
 	<h2><a href="https://wiki.openmrs.org">OpenMRS Wiki</a></h2>
 	<a class="sub" href="https://wiki.openmrs.org/users/viewmyprofile.action">View Profile</a>
 </div>
 
-<div class="box">
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/jira.png" alt="JIRA"></div>
 	<h2><a href="https://tickets.openmrs.org">JIRA Issue Tracking</a></h2>
 	<a class="sub" href="https://tickets.openmrs.org/secure/ViewProfile.jspa">View Profile</a>
 </div>
 
-<div class="box">
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/fisheye.png"></div>
 	<h2><a href="https://source.openmrs.org">FishEye + Crucible Source</a></h2>
 	<a class="sub" href="https://source.openmrs.org/profile/">View Profile</a>
 </div>
 
-<div class="box">
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/osqa.png" alt="OpenMRS Answers"></div>
 	<h2><a href="https://answers.openmrs.org">OpenMRS Answers</a></h2>
 	<% if (osqaUser) { %>
@@ -42,13 +43,13 @@ With your OpenMRS ID, you can log in to use the services below:</p>
 	<% } %>
 </div>
 
-<div class="box">
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/bamboo.png" alt="Continuous Integration"></div>
 	<h2><a href="https://ci.openmrs.org">Continuous Integration</a></h2>
 	<a class="sub" href="https://ci.openmrs.org/profile/userProfile.action">View Profile</a>
 </div>
 
-<div class="box">
+<div class="box col-md-5">
 	<div class="logo"><img src="/resource/images/service_logos/other.png" alt="Other Services"></div>
 	<h2>Other…</h2>
 	<a class="sub" href="https://svn.openmrs.org">Subversion</a><br>


### PR DESCRIPTION
This fixes the css fail that has been going on in the "services" section of the signed-in page:

![screen shot 2014-07-18 at 13 53 15](https://cloud.githubusercontent.com/assets/910198/3630468/a4fc7a9e-0eab-11e4-9184-cdcda14f32b7.png)

Unfortunately some other small changes I had been working on slipped in to this branch (bad git ftw). They are:
- installing the express debug toolbar, which only runs in dev mode
- including the mongoose models in `Common`. this allows them to be access from external components, like modules
