### PR TITLE
fix ID-51, groups relation now will be automatically handled in middlewa...

### DIFF
--- a/app/model/group.js
+++ b/app/model/group.js
@@ -34,7 +34,14 @@ var groupSchema = new Schema({
   inLDAP: {
     type: Boolean,
     default: false,
-  }
+  },
+
+  // Special flag used to skip the LDAP procedure.
+  // Note that this flag will be deleted in pre middleware,
+  // so it will only works once.
+  skipLDAP: {
+    type: Boolean,
+  },
 });
 
 if ('production' === process.env.NODE_ENV) {
@@ -44,6 +51,9 @@ if ('production' === process.env.NODE_ENV) {
 // pre hooks used to sync with LDAP,
 // currently we only support to add, no modification
 groupSchema.pre('save', function (next) {
+  if (this.skipLDAP) {
+    return next();
+  }
   if (this.inLDAP) {
     return next();
   }
@@ -60,3 +70,13 @@ groupSchema.pre('save', function (next) {
 var Group = mongoose.model('Group', groupSchema);
 
 exports = module.exports = Group;
+
+Group.prototype.indexOfUser = function(username) {
+  username = username.toLowerCase();
+  for (var i = 0, len = this.member.length; i < len; ++i) {
+    if (this.member[i].username === username) {
+      return i;
+    }
+  }
+  return -1;
+};

--- a/app/model/group.js
+++ b/app/model/group.js
@@ -52,6 +52,7 @@ if ('production' === process.env.NODE_ENV) {
 // currently we only support to add, no modification
 groupSchema.pre('save', function (next) {
   if (this.skipLDAP) {
+    this.skipLDAP = undefined;
     return next();
   }
   if (this.inLDAP) {


### PR DESCRIPTION
Fixed ID-51, now we'll use the middleware to automatically update(add/delete) the groups relation.

That means, the `User#addGroupsAndSave()` can be deprecated now.

Also I added a `skipLDAP` attribute in Group model for consistency. Actually it's not good to add this kind of temporary flag into `Schema`. But if I don't implement it this way, I will lost the `skipLDAP` after calling constructor.

e.g.
Tihs works,

``` javascript
var blah = {
  //blahblah
};
user = new User(blah);
user.skipLDAP = true;
```

This doesn't,

``` javascript
var blah = {
  skipLDAP: true,
  //blahblah
};
user = new User(blah);
```

Anyway, not a big deal.
