### PR TITLE
ID 49: Admin access to Formage console

### DIFF
--- a/app/system-modules/db-admin/index.js
+++ b/app/system-modules/db-admin/index.js
@@ -7,6 +7,7 @@ var mid = Common.mid;
 var fields = require('./lib/fields');
 var widgets = require('./lib/widgets');
 var syncAdminUsers = require('./lib/syncAdminUsers');
+var admin = Common.module.admin;
 
 var app = Common.app;
 
@@ -23,6 +24,8 @@ var registry = formage.init(app, express, models, {
 });
 
 syncAdminUsers(registry.models.formage_users_.model, models.user);
+
+admin.addModulePage('Data Management (Formage)', '/panel');
 
 module.exports = {
   fields: fields,

--- a/app/system-modules/db-admin/index.js
+++ b/app/system-modules/db-admin/index.js
@@ -3,10 +3,13 @@ var formage = require('formage');
 var models = require('./model');
 var Common = require(global.__commonModule);
 var conf = Common.conf;
+var mid = Common.mid;
 var fields = require('./lib/fields');
 var widgets = require('./lib/widgets');
 
 var app = Common.app;
+
+app.use('/panel', mid.restrictTo('dashboard-administrators'));
 
 formage.init(app, express, models, {
   title: 'OpenMRS ID Database Admin',

--- a/app/system-modules/db-admin/index.js
+++ b/app/system-modules/db-admin/index.js
@@ -6,23 +6,28 @@ var conf = Common.conf;
 var mid = Common.mid;
 var fields = require('./lib/fields');
 var widgets = require('./lib/widgets');
+var syncAdminUsers = require('./lib/syncAdminUsers');
 
 var app = Common.app;
 
 app.use('/panel', mid.restrictTo('dashboard-administrators'));
 
-formage.init(app, express, models, {
-  title: 'OpenMRS ID Database Admin',
+var registry = formage.init(app, express, models, {
+  title: 'OpenMRS ID Management',
   root: '/panel',
-  default_section: 'main',
+  default_section: 'OpenMRS ID',
   username: conf.mongo.username,
   password: conf.mongo.password,
-  admin_users_gui: true
+  admin_users_gui: false,
+  no_users: false
 });
+
+syncAdminUsers(registry.models.formage_users_.model, models.user);
 
 module.exports = {
   fields: fields,
-  widgets: widgets
+  widgets: widgets,
+  registry: registry
 };
 
 Common.module.dbAdmin = module.exports;

--- a/app/system-modules/db-admin/lib/syncAdminUsers.js
+++ b/app/system-modules/db-admin/lib/syncAdminUsers.js
@@ -1,0 +1,103 @@
+var async = require('async');
+var q = require('q');
+var Common = require(global.__commonModule);
+var log = Common.logger.add('db-admin');
+var formage = require('formage');
+var utils = Common.utils;
+var _ = require('lodash');
+
+var FormageUser;
+var User;
+
+function syncFormageUser(user, callback) {
+
+  return FormageUser.findOne({username: user.username}).exec()
+  .then(function(formageUser) {
+
+    return (formageUser)
+      ? updatePassword(formageUser, user)
+      : createFormageUser(user);
+
+  })
+  .then(function(formageUser) {
+
+    var deferred = q.defer();
+
+    if (formageUser.isModified()) {
+      return formageUser.save(function(err, fu) {
+        if (err) deferred.reject(err);
+        else deferred.resolve(fu);
+      });
+
+    } else {
+      deferred.resolve(formageUser);
+    }
+
+    return deferred.promise;
+
+  })
+  .then(function(formageUser) {
+
+    log.debug('formage user ' + formageUser.username + ' saved');
+
+    return (callback)
+      ? callback(null, formageUser)
+      : formageUser;
+
+  }, onError);
+}
+
+function createFormageUser(user) {
+
+  var fu = new FormageUser({
+    username: user.username,
+    passwordHash: user.password,
+    is_superuser: true
+  });
+
+  updatePassword(fu, user);
+
+  return fu;
+
+}
+
+function updatePassword(fu, user) {
+  fu.passwordHash = user.password;
+  return fu;
+}
+
+function onSave(user) {
+
+  syncFormageUser(user);
+}
+
+function onError(err) {
+  log.error(err);
+  return err;
+}
+
+module.exports = function init(_FormageUser_, _User_) {
+
+  FormageUser = _FormageUser_;
+  User = _User_;
+
+  User.schema.post('save', onSave);
+
+  User.find({groups: 'dashboard-administrators'}).exec()
+  .then(function(users) {
+
+    log.debug('found', users.length, 'dashboard administrators');
+
+    async.each(users, syncFormageUser, function() {
+      log.info('Synced all dashboard admin users to Formage user models.');
+    });
+
+  }, onError);
+
+};
+
+
+// Override UserForm methods with our own
+var salt = 'wherestheninja'; // same salt formage uses internally
+formage.UserForm.encryptSync = _.partialRight(utils.getSSHA, salt);
+formage.UserForm.compareSync = utils.checkSSHA;

--- a/app/system-modules/db-admin/lib/syncAdminUsers.js
+++ b/app/system-modules/db-admin/lib/syncAdminUsers.js
@@ -99,7 +99,10 @@ function updatePassword(fu, user) {
  */
 function onSave(user) {
 
-  syncFormageUser(user);
+  if (_.contains(user.groups, 'dashboard-administrators')) {
+    syncFormageUser(user);
+  }
+
 }
 
 /**
@@ -133,7 +136,7 @@ module.exports = function init(_FormageUser_, _User_) {
   User.find({groups: 'dashboard-administrators'}).exec()
   .then(function (users) {
 
-    log.debug('found ' + users.length + 'dashboard administrator(s)');
+    log.debug('found ' + users.length + ' dashboard administrator(s)');
 
     async.each(users, syncFormageUser, function (err) {
 

--- a/app/system-modules/db-admin/model/group.js
+++ b/app/system-modules/db-admin/model/group.js
@@ -2,6 +2,8 @@ var path = require('path');
 var Group = require(path.join(global.__apppath, 'model/group'));
 
 Group.formage = {
+  label: 'Groups',
+
   list: [
     'groupName',
     'description',

--- a/app/system-modules/db-admin/model/user.js
+++ b/app/system-modules/db-admin/model/user.js
@@ -2,7 +2,7 @@ var path = require('path');
 var User = require(path.join(global.__apppath, 'model/user'));
 
 User.formage = {
-  label: 'OpenMRS ID',
+  label: 'Users',
 
   // filters: [
   //   'username',

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "connect-flash": "~0.1.1",
     "ejs-locals": "~1.0.2",
     "xml2js": "~0.1.14",
-    "formage": "~2.7.33",
+    "formage": "^2.7.33",
     "mysql": "~2.3.2",
     "should": "~2.1.1",
     "supertest": "~0.8.3",
     "chai": "~1.9.1",
-    "mocha": "~1.16.2"
+    "mocha": "~1.16.2",
+    "q": "^1.0.1"
   },
   "engine": {
     "node": "~0.8.26"


### PR DESCRIPTION
This change syncs OpenMRS IDs that are members of the "dashboard-administrators" group with Formage's internal list of users. In other words, admins can use their OpenMRS ID credentials to log in to Formage. In other, other words, it makes Formage actually usable for us :-)

It also adds a link to formage in the Admin sidebar, and blocks access to the formage panel url "/panel" for users who aren't admins, as a security precaution.
